### PR TITLE
docs: add README quickstart and align local asset paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,62 @@
+# Hazama
+
+Hazama は、深度データ (`hazama-depths.json`) を読み込み、選択肢を辿ってストーリー深度を移動する静的 Web アプリです。
+
+## 現在の構成
+
+- `hazama-index.html` : エントリーポイント
+- `hazama-main.js` : 画面描画と深度データ読み込みロジック
+- `hazama-style.css` : スタイル
+- `hazama-depths.json` : 深度定義データ
+
+## 最短のローカル起動方法
+
+`file://` 直開きでは JSON の読み込みで問題が起きることがあるため、HTTP サーバ経由で起動してください。
+
+### Python を使う場合
+
+```bash
+python -m http.server 8000
+```
+
+ブラウザで `http://localhost:8000/hazama-index.html` を開きます。
+
+### Node.js を使う場合
+
+```bash
+npx serve .
+```
+
+表示されたローカル URL にアクセスし、`/hazama-index.html` を開きます。
+
+## 推奨開発フロー
+
+1. ブランチを作成する
+2. 変更する
+3. ローカルで HTTP サーバを起動して確認する
+4. 差分を確認する
+5. commit する
+6. PR を作成する（`main` へ直接 push しない）
+
+例:
+
+```bash
+git switch -c docs/readme-quickstart
+python -m http.server 8000
+# ブラウザで動作確認
+git status
+git add .
+git commit -m "docs: add README quickstart"
+git push -u origin docs/readme-quickstart
+```
+
+## 命名整理の提案（次PR候補）
+
+将来的には、GitHub Pages 互換性と一般的な構成に寄せるため、以下への統一を推奨します。
+
+- `hazama-index.html` → `index.html`
+- `hazama-main.js` → `main.js`
+- `hazama-style.css` → `style.css`
+- `hazama-depths.json` → `depths.json`
+
+今回の変更では既存ファイルを壊さない方針で、参照名を現在のファイル名に揃える最小修正に留めています。

--- a/hazama-index.html
+++ b/hazama-index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <title>Hazama / Depth Navigator</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <link rel="stylesheet" href="style.css" />
+  <link rel="stylesheet" href="hazama-style.css" />
 </head>
 <body>
   <main id="app">
@@ -25,9 +25,9 @@
   </main>
 
   <footer class="hz-footer">
-    <small>GitHub Raw depths.json をリアルタイム読込中（Hazama main.js v1.4）</small>
+    <small>ローカル hazama-depths.json を読込中（Hazama main.js v1.5）</small>
   </footer>
 
-  <script src="main.js"></script>
+  <script src="hazama-main.js"></script>
 </body>
 </html>

--- a/hazama-main.js
+++ b/hazama-main.js
@@ -1,10 +1,10 @@
-// Hazama main.js v1.4
-// 完全キャッシュ破壊 + Raw最新版強制 + 安全一式
+// Hazama main.js v1.5
+// ローカルJSON読込 + キャッシュ回避 + 安全一式
 
 // --- 設定 ---
 function buildDepthsURL() {
-  // GitHub Raw の完全キャッシュ破壊
-  const base = "https://raw.githubusercontent.com/QuietBriony/hazama/master/depths.json";
+  // ローカル配置の深度データを参照
+  const base = "./hazama-depths.json";
   return `${base}?t=${Date.now()}&rnd=${Math.random()}`;
 }
 


### PR DESCRIPTION
### Motivation

- Provide a minimal quickstart so the static Hazama app can be run locally via HTTP and is easier for contributors to verify. 
- Ensure the existing on-disk filenames are referenced by the HTML/JS so the app works out-of-the-box without renaming files. 

### Description

- Add `README.md` that documents current project structure, shortest local startup (`python -m http.server 8000` / `npx serve .`), recommended dev flow, and a future filename-normalization proposal. 
- Update `hazama-index.html` to reference `hazama-style.css` and `hazama-main.js` and update the footer text to reflect local JSON loading. 
- Update `hazama-main.js` (bump to v1.5 in comment) so it loads the local `./hazama-depths.json` with cache-busting query parameters and retains safe `fetch` options. 

### Testing

- Ran `python -m json.tool hazama-depths.json` to validate JSON formatting and it succeeded. 
- Launched a local HTTP server with `python -m http.server 8000` and used `curl -I` to fetch `http://127.0.0.1:8000/hazama-index.html` and `http://127.0.0.1:8000/hazama-depths.json`, both returned `200 OK`. 
- Captured a browser screenshot of `http://127.0.0.1:8000/hazama-index.html` using a Playwright script to verify the page renders, and the script completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e7368d13c832e8563c7ba2dccf667)